### PR TITLE
Add 'ago' postfix to the timeago'd changelog date

### DIFF
--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -56,7 +56,7 @@ export default ({ site, colors } = {}) => {
           level,
           title
         )}<time class="loglive-date" datetime="${date &&
-          parseDate(date)}">${date && timeago(date)} ago</time></div>`
+          parseDate(date)}">${date && timeago(date, { addSuffix: true })}</time></div>`
       }
     }
 

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -56,7 +56,7 @@ export default ({ site, colors } = {}) => {
           level,
           title
         )}<time class="loglive-date" datetime="${date &&
-          parseDate(date)}">${date && timeago(date)}</time></div>`
+          parseDate(date)}">${date && timeago(date)} ago</time></div>`
       }
     }
 


### PR DESCRIPTION
Hello,

I love the simplicity of this app, I think it's really great. This change is a very simple one. I'm proposing adding 'ago' to the end of the date rendering such that '7 hours' or '20 days' now becomes '7 hours ago' and '20 days ago', respectively.

Thanks!